### PR TITLE
Add Docker Compose Startup Instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use Golang image based on Debian Bookworm
+FROM golang:bookworm
+
+# Set the working directory within the container
+WORKDIR /app
+
+# Clone the repository
+RUN git clone https://github.com/bitvora/wot-relay . 
+
+# Download Go module dependencies
+RUN go mod download
+
+# Write the .env file
+RUN touch .env && \
+    echo "RELAY_NAME=${RELAY_NAME}" >> .env && \
+    echo "RELAY_PUBKEY=${RELAY_PUBKEY}" >> .env && \
+    echo "RELAY_DESCRIPTION=${RELAY_DESCRIPTION}" >> .env && \
+    echo "DB_PATH=${DB_PATH}" >> .env
+
+# Build the Go application
+RUN go build -o main .
+
+# Expose the port that the application will run on
+EXPOSE 3334
+
+# Set the command to run the executable
+CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,21 @@ sudo systemctl start wot-relay
 sudo systemctl enable wot-relay
 ```
 
-### 6. Access the relay
+### 6. Start the Project with Docker Compose (optional)
+
+To start the project using Docker Compose, follow these steps:
+
+1. Ensure Docker and Docker Compose are installed on your system.
+2. Navigate to the project directory.
+3. Run the following command:
+
+    ```sh
+    docker-compose up --build
+    ```
+
+This will build the Docker image and start the `wot-relay` service as defined in the `docker-compose.yml` file. The application will be accessible on port 3334.
+
+### 7. Access the relay
 
 Once everything is set up, the relay will be running on `localhost:3334`.
 

--- a/README.md
+++ b/README.md
@@ -91,19 +91,30 @@ sudo systemctl start wot-relay
 sudo systemctl enable wot-relay
 ```
 
-### 6. Start the Project with Docker Compose (optional)
+### 6. Start the Project with Docker Compose
 
 To start the project using Docker Compose, follow these steps:
 
 1. Ensure Docker and Docker Compose are installed on your system.
 2. Navigate to the project directory.
-3. Run the following command:
+3. Edit the `docker-compose.yml` file to update the environment variables as needed:
+
+    ```yaml
+    environment:
+        RELAY_NAME: "utxo WoT relay"
+        RELAY_PUBKEY: "YOURPUBKEY"
+        RELAY_DESCRIPTION: "Only notes in utxo WoT"
+        DB_PATH: "./db"
+    ```
+
+4. Run the following command:
 
     ```sh
     docker-compose up --build
     ```
 
 This will build the Docker image and start the `wot-relay` service as defined in the `docker-compose.yml` file. The application will be accessible on port 3334.
+
 
 ### 7. Access the relay
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo systemctl start wot-relay
 sudo systemctl enable wot-relay
 ```
 
-### 6. Start the Project with Docker Compose
+### 6. Start the Project with Docker Compose (optional)
 
 To start the project using Docker Compose, follow these steps:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  wot-relay:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+        RELAY_NAME: "utxo WoT relay"
+        RELAY_PUBKEY: "e2ccf7cf20403f3f2a4a55b328f0de3be38558a7d5f33632fdaaefc726c1c8eb"
+        RELAY_DESCRIPTION: "Only notes in utxo WoT"
+        DB_PATH: "./db"
+    volumes:
+      - "./db:/app/db"
+    ports:
+      - "3334:3334"


### PR DESCRIPTION
- Updated README.md with a new section on how to start the project using Docker Compose.
- Included instructions to ensure Docker and Docker Compose are installed.
- Detailed steps for navigating to the project directory and building the Docker image.
- Added a note to edit the docker-compose.yml file to update environment variables.
- Explained how to start the wot-relay service.