### PR TITLE
don't fail when a `.env` file is not present

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,10 +119,7 @@ func main() {
 }
 
 func LoadConfig() Config {
-	err := godotenv.Load(".env")
-	if err != nil {
-		log.Fatalf("Error loading .env file")
-	}
+	godotenv.Load(".env")
 
 	config := Config{
 		RelayName:        getEnv("RELAY_NAME"),


### PR DESCRIPTION
still try to read it but let people use other ways to set up their environment variables.