### PR TITLE
fix http: panic serving <local_ip_here>: open public/index.html with docker compose

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -7,8 +7,8 @@ services:
     env_file:
       - .env
     volumes:
-      - "./db:/app/db" # only change the left side before the colon
-      - "./templates/index.html:/app/templates/index.html" # only change the left side before the colon
-      - "./templates/static:/app/templates/static" # only change the left side before the colon
+      - "./db:/app/db"
+      - "./templates/index.html:${INDEX_PATH}"
+      - "./templates/static:${STATIC_PATH}"
     ports:
       - "3334:3334"

--- a/docker-compose.tor.yml
+++ b/docker-compose.tor.yml
@@ -8,8 +8,8 @@ services:
       - .env
     volumes:
       - "./db:/app/db"
-      - "./templates/index.html:/app/templates/index.html"
-      - "./templates/static:/app/templates/static"
+      - "./templates/index.html:${INDEX_PATH}"
+      - "./templates/static:${STATIC_PATH}"
     ports:
       - "3334"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     env_file:
       - .env
     volumes:
-      - "./db:/app/db" # only change the left side before the colon
-      - "./templates/index.html:/app/templates/index.html" # only change the left side before the colon
-      - "./templates/static:/app/templates/static" # only change the left side before the colon
+      - "./db:/app/db"
+      - "./templates/index.html:${INDEX_PATH}"
+      - "./templates/static:${STATIC_PATH}"
     ports:
       - "3334:3334"


### PR DESCRIPTION
See issue noted by @calvadev here: https://njump.me/nevent1qvzqqqqqqypzp5mwszpl57ekmthxgm9ck0uel64rmz095wt9pp6p7qp7yxkqk6lvqqsd3pgudy4pu35wz5ps9tf8ddfaum5wwafp8qymysslpvslqywlhac8r6tp9

causing this error

```bash
http: panic serving <local_ip_here>: open public/index.html: no such file or directory
```

I fixed this by replacing the volume path `/app/templates/index.html` with the `.env` variable `${INDEX_PATH}` in `docker-compose.yml`. Also did the same for the static path.