### PR TITLE
Delete / prune old archived notes from relay.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ MINIMUM_FOLLOWERS=5
 
 # archive all notes from everyone in your WoT from other relays
 ARCHIVAL_SYNC="FALSE"
+
+# optional, certain note kinds older than this many days will be deleted
+MAX_AGE_DAYS=365


### PR DESCRIPTION
Added a function that deletes certain note kinds based on a new environment variable MAX_AGE_DAYS. 

For example, if MAX_AGE_DAYS is set to 365, notes 365 days and older will be deleted from the relay.  If MAX_AGE_DAYS is set to zero or not used the feature is disabled.

The feature is coded so that only 'old' notes of the same kinds as those retrieved during archiveTrustedNotes() are deleted.