### PR TITLE
Add wot.dergigi.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Don't want to run the relay, just want to connect to some? Here are some availab
 - [wss://wot.tealeaf.dev](https://wot.tealeaf.dev)
 - [wss://wot.nostr.net](https://wot.nostr.net)
 - [wss://relay.goodmorningbitcoin.com](https://relay.goodmorningbitcoin.com)
-- [wss://wot.sudocarlos.com](wss://wot.sudocarlos.com)
+- [wss://wot.sudocarlos.com](https://wot.sudocarlos.com)
+- [wss://wot.dergigi.com/](https://wot.dergigi.com/)
 
 ## Prerequisites
 


### PR DESCRIPTION
- https://wot.dergigi.com/
- `wss://wot.dergigi.com/`

Also fixes the link of [wot.sudocarlos.com](https://wot.sudocarlos.com/) which was wrongly pointing to `wss://` instead of `https://` (so the link wouldn't actually be hyperlinked, making it look weird in the readme).