### PR TITLE
Remove offline relays from README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,15 @@ WOT Relay is a Nostr relay that saves all the notes that people you follow, and 
 
 Don't want to run the relay, just want to connect to some? Here are some available relays:
 
-- [wss://wot.utxo.one](https://wot.utxo.one)
 - [wss://nostrelites.org](https://nostrelites.org)
 - [wss://wot.nostr.party](https://wot.nostr.party)
-- [wss://wot.sovbit.host](https://wot.sovbit.host)
 - [wss://wot.girino.org](https://wot.girino.org)
-- [wss://relay.lnau.net](https://relay.lnau.net)
-- [wss://wot.siamstr.com](https://wot.siamstr.com)
 - [wss://relay.lexingtonbitcoin.org](https://relay.lexingtonbitcoin.org)
 - [wss://wot.azzamo.net](https://wot.azzamo.net)
-- [wss://wot.swarmstr.com](https://wot.swarmstr.com)
-- [wss://zap.watch](https://zap.watch)
 - [wss://satsage.xyz](https://satsage.xyz)
-- [wss://wons.calva.dev](https://wons.calva.dev)
-- [wss://wot.zacoos.com](https://wot.zacoos.com)
 - [wss://wot.shaving.kiwi](https://wot.shaving.kiwi)
-- [wss://wot.tealeaf.dev](https://wot.tealeaf.dev)
 - [wss://wot.nostr.net](https://wot.nostr.net)
 - [wss://relay.goodmorningbitcoin.com](https://relay.goodmorningbitcoin.com)
-- [wss://wot.sudocarlos.com](https://wot.sudocarlos.com)
 - [wss://wot.dergigi.com/](https://wot.dergigi.com/)
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Tested each of the 20 relays listed under "Available Relays" with `nak req -k 1 -l 1 <relay>`.
- Removed 10 relays that failed to respond: `wot.utxo.one`, `wot.sovbit.host`, `relay.lnau.net`, `wot.siamstr.com`, `wot.swarmstr.com`, `zap.watch`, `wons.calva.dev`, `wot.zacoos.com`, `wot.tealeaf.dev`, `wot.sudocarlos.com`.
- Failure modes: DNS NXDOMAIN, HTTP 5xx, expired/mismatched TLS certs, and connection timeouts.

## Test plan
- [ ] Re-run `nak req -k 1 -l 1` against each remaining relay to confirm it still accepts queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)