### PR TITLE
Update NIP-11 software URL and version to 0.2.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	version string
+	version = "0.2.1"
 )
 
 type Config struct {
@@ -148,7 +148,7 @@ func main() {
 		Description: config.RelayDescription,
 		Contact:     config.RelayContact,
 		Icon:        config.RelayIcon,
-		Software:    "https://github.com/bitvora/wot-relay",
+		Software:    "https://github.com/barrydeen/wot-relay",
 		Version:     version,
 	}
 	if pk, err := nostr.PubKeyFromHex(config.RelayPubkey); err == nil {


### PR DESCRIPTION
## Summary
- Set NIP-11 `Software` to `https://github.com/barrydeen/wot-relay` (was `bitvora/wot-relay`).
- Default the `version` var to `0.2.1`. Nothing in-tree injects it via ldflags, so previously the relay advertised an empty version string.

## Notes
- Two non-NIP-11 references to the old repo remain (`Dockerfile:21` comment, `README.md:42` clone URL). Left untouched to keep this PR scoped — happy to update in a follow-up if you want.

## Test plan
- [x] `go build ./...` passes locally.
- [ ] Verify `/` with `Accept: application/nostr+json` returns the new software URL and version after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)